### PR TITLE
hwcomposer: Work around overzealous fortify checks

### DIFF
--- a/libhwcomposer/hwc_vsync.cpp
+++ b/libhwcomposer/hwc_vsync.cpp
@@ -151,7 +151,7 @@ static void *vsync_loop(void *param)
 
     if (LIKELY(!ctx->vstate.fakevsync)) {
         do {
-            int err = poll(*pfd, num_displays * num_events, -1);
+            int err = poll(reinterpret_cast<struct pollfd *>(pfd), num_displays * num_events, -1);
             if(err > 0) {
                 for (int dpy = HWC_DISPLAY_PRIMARY; dpy < num_displays; dpy++) {
                     for(size_t ev = 0; ev < num_events; ev++) {


### PR DESCRIPTION
Storage for six pollfd structs is allocated on the stack in a 2d array.
Subsequently, the address of the first element is passed to poll along
with the same total number of fds.  At this point, the fortify dynamic
checker, considering only one of the dimensions of the array, throws an
error and warns that array is too small.  Since the array is actually
sized appropriately, use a reinterpret_cast to subvert the checker.

Bug: 77323983
Change-Id: Ib88c5a00bc84b3d05be95baf57df5f522a769da4